### PR TITLE
Edited src/main/java/com/google/api/translate/Language.java via GitHub

### DIFF
--- a/src/main/java/com/google/api/translate/Language.java
+++ b/src/main/java/com/google/api/translate/Language.java
@@ -136,7 +136,7 @@ public enum Language {
 	
 	public static Language fromString(final String pLanguage) {
 		for (Language l : values()) {
-			if (pLanguage.equals(l.toString())) {
+			if (l.toString().equals(pLanguage)) {
 				return l;
 			}
 		}


### PR DESCRIPTION
the toString() method throws a NullPointerException if you pass in a null object.

Fixed by changing which class performs the equals() to the one we know will never be null.

Now it should correctly return null.
